### PR TITLE
Add redis support

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 black
+redislite

--- a/src/pycrowdsec/cache.py
+++ b/src/pycrowdsec/cache.py
@@ -3,9 +3,14 @@ from itertools import chain
 
 
 class Cache:
-    def __init__(self):
+    def __init__(self, **kwargs):
         self.ip_cache = IPCache()
         self.normal_cache = {}
+        self.use_redis = False
+        if "redis_connection" in kwargs:
+            self.use_redis = True
+            self.redis = kwargs["redis_connection"]
+            self.load_from_redis()
 
     def get(self, item):
         try:
@@ -16,23 +21,60 @@ class Cache:
 
     def insert(self, item, action):
         try:
-            ipaddress.ip_network(item)
+            ip = ipaddress.ip_network(item)
             self.ip_cache.insert(item, action)
+            if self.use_redis:
+                self.redis.hset(
+                    "pycrowdsec_cache",
+                    f"ipv{ip.version}_{int(ip.netmask)}_{int(ip.network_address)}",
+                    action,
+                )
+
         except ValueError:
             self.normal_cache[item] = action
+            if self.use_redis:
+                self.redis.hset("pycrowdsec_cache", f"normal_{item}", action)
 
     def delete(self, item):
         try:
-            ipaddress.ip_network(item)
+            ip = ipaddress.ip_network(item)
             self.ip_cache.delete(item)
+            if self.use_redis:
+                self.redis.hdel(
+                    "pycrowdsec_cache",
+                    f"ipv{ip.version}_{int(ip.netmask)}_{int(ip.network_address)}",
+                )
         except ValueError:
             try:
                 del self.normal_cache[item]
+                if self.use_redis:
+                    self.redis.hdel("pycrowdsec_cache", f"normal_{item}")
             except KeyError:
                 pass
 
+    def load_from_redis(self):
+        for key, value in self.redis.hgetall("pycrowdsec_cache").items():
+            key, value = key.decode(), value.decode()
+            if key.startswith("normal"):  # normal_CN = "ban"
+                key = key.split("_", maxsplit=1)[1]
+                self.normal_cache[key] = value
+            elif key.startswith("ipv4"):  # normal_0_1.2.3.4 = "captcha"
+                key_comps = key.split("_")
+                netmask, ip = int(key_comps[1]), int(key_comps[-1])
+                self.ip_cache.ipv4_nodes_by_netmask[netmask][ip] = value
+            elif key.startswith("ipv6"):
+                key_comps = key.split("_")
+                netmask, ip = int(key_comps[1]), int(key_comps[-1])
+                self.ip_cache.ipv6_nodes_by_netmask[netmask][ip] = value
+
+    def validate_redis_config(self):
+        pass
+
     def __len__(self):
         return len(self.normal_cache) + len(self.ip_cache)
+
+    def __eq__(self, other):
+        return self.normal_cache == other.normal_cache and self.ip_cache == other.ip_cache
 
 
 class IPCache:
@@ -79,3 +121,9 @@ class IPCache:
         ):
             length += len(items)
         return length
+
+    def __eq__(self, other):
+        return (
+            self.ipv4_nodes_by_netmask == other.ipv4_nodes_by_netmask
+            and self.ipv6_nodes_by_netmask == other.ipv6_nodes_by_netmask
+        )

--- a/src/pycrowdsec/cache.py
+++ b/src/pycrowdsec/cache.py
@@ -1,129 +1,76 @@
 import ipaddress
-from itertools import chain
+
+IPV4_NETMASKS = [int(ipaddress.ip_network(f"0.0.0.0/{i}").netmask) for i in range(32, -1, -1)]
+
+IPV6_NETMASKS = [int(ipaddress.ip_network(f"::/{i}").netmask) for i in range(128, -1, -1)]
+
+NETMASKS_BY_KEY_TYPE = {"ipv4": IPV4_NETMASKS, "ipv6": IPV6_NETMASKS}
+
+
+def item_to_string(item):
+    try:
+        ip = ipaddress.ip_network(item)
+        return f"ipv{ip.version}_{int(ip.netmask)}_{int(ip.network_address)}"
+    except ValueError:
+        return f"normal_{item}"
 
 
 class Cache:
-    def __init__(self, **kwargs):
-        self.ip_cache = IPCache()
-        self.normal_cache = {}
-        self.use_redis = False
-        if "redis_connection" in kwargs:
-            self.use_redis = True
-            self.redis = kwargs["redis_connection"]
-            self.load_from_redis()
+    def __init__(self):
+        self.cache = {}
 
     def get(self, item):
-        try:
-            ipaddress.ip_address(item)
-            return self.ip_cache.get_action_for(item)
-        except ValueError:
-            return self.normal_cache.get(item)
+        key = item_to_string(item)
+        key_parts = key.split("_")
+        key_type = key_parts[0]
+        if key_type == "normal":
+            return self.cache.get(key)
+        item_network_address = int(key_parts[-1])
+        netmasks = NETMASKS_BY_KEY_TYPE[key_type]
+        for netmask in netmasks:
+            resp = self.cache.get(f"{key_type}_{netmask}_{item_network_address & netmask}")
+            if resp:
+                return resp
 
     def insert(self, item, action):
-        try:
-            ip = ipaddress.ip_network(item)
-            self.ip_cache.insert(item, action)
-            if self.use_redis:
-                self.redis.hset(
-                    "pycrowdsec_cache",
-                    f"ipv{ip.version}_{int(ip.netmask)}_{int(ip.network_address)}",
-                    action,
-                )
-
-        except ValueError:
-            self.normal_cache[item] = action
-            if self.use_redis:
-                self.redis.hset("pycrowdsec_cache", f"normal_{item}", action)
+        key = item_to_string(item)
+        self.cache[key] = action
 
     def delete(self, item):
-        try:
-            ip = ipaddress.ip_network(item)
-            self.ip_cache.delete(item)
-            if self.use_redis:
-                self.redis.hdel(
-                    "pycrowdsec_cache",
-                    f"ipv{ip.version}_{int(ip.netmask)}_{int(ip.network_address)}",
-                )
-        except ValueError:
-            try:
-                del self.normal_cache[item]
-                if self.use_redis:
-                    self.redis.hdel("pycrowdsec_cache", f"normal_{item}")
-            except KeyError:
-                pass
-
-    def load_from_redis(self):
-        for key, value in self.redis.hgetall("pycrowdsec_cache").items():
-            key, value = key.decode(), value.decode()
-            if key.startswith("normal"):  # normal_CN = "ban"
-                key = key.split("_", maxsplit=1)[1]
-                self.normal_cache[key] = value
-            elif key.startswith("ipv4"):  # normal_0_1.2.3.4 = "captcha"
-                key_comps = key.split("_")
-                netmask, ip = int(key_comps[1]), int(key_comps[-1])
-                self.ip_cache.ipv4_nodes_by_netmask[netmask][ip] = value
-            elif key.startswith("ipv6"):
-                key_comps = key.split("_")
-                netmask, ip = int(key_comps[1]), int(key_comps[-1])
-                self.ip_cache.ipv6_nodes_by_netmask[netmask][ip] = value
-
-    def validate_redis_config(self):
-        pass
+        key = item_to_string(item)
+        self.cache.pop(key, None)
 
     def __len__(self):
-        return len(self.normal_cache) + len(self.ip_cache)
-
-    def __eq__(self, other):
-        return self.normal_cache == other.normal_cache and self.ip_cache == other.ip_cache
+        return len(self.cache)
 
 
-class IPCache:
-    def __init__(self):
-        # This "reverse range" comprehension is deliberate. Since dicts are ordered
-        # when we iterate on them, we get the "more specific"/smaller network first.
-        self.ipv4_nodes_by_netmask = {
-            int(ipaddress.ip_network(f"0.0.0.0/{i}").netmask): {} for i in range(32, -1, -1)
-        }
-        self.ipv6_nodes_by_netmask = {
-            int(ipaddress.ip_network(f"::/{i}").netmask): {} for i in range(128, -1, -1)
-        }
+class RedisCache:
+    def __init__(self, redis_connection):
+        self.redis = redis_connection
 
-    def _get_container_for_ip_network(self, ip_network):
-        if ip_network.version == 4:
-            return self.ipv4_nodes_by_netmask
-        return self.ipv6_nodes_by_netmask
+    def get(self, item):
+        key = item_to_string(item)
+        key_parts = key.split("_")
+        key_type = key_parts[0]
+        if key_type == "normal":
+            return self.redis.hget("pycrowdsec_cache", key)
+        item_network_address = int(key_parts[-1])
+        netmasks = NETMASKS_BY_KEY_TYPE[key_type]
+        check_for = []
+        for netmask in netmasks:
+            check_for.append(f"{key_type}_{netmask}_{item_network_address & netmask}")
+        responses = self.redis.hmget("pycrowdsec_cache", check_for)
+        for response in responses:
+            if response:
+                return response
 
-    def insert(self, ip_network_string, action):
-        ip_network = ipaddress.ip_network(ip_network_string)
-        container = self._get_container_for_ip_network(ip_network)
-        container[int(ip_network.netmask)][int(ip_network.network_address)] = action
+    def insert(self, item, action):
+        key = item_to_string(item)
+        self.redis.hset("pycrowdsec_cache", key, action)
 
-    def delete(self, ip_network_string):
-        ip_network = ipaddress.ip_network(ip_network_string)
-        container = self._get_container_for_ip_network(ip_network)
-        try:
-            del container[int(ip_network.netmask)][int(ip_network.network_address)]
-        except KeyError:
-            pass
-
-    def get_action_for(self, ip_network_string):
-        ip_network = ipaddress.ip_network(ip_network_string)
-        ip_decimal_repr = int(ip_network.network_address)
-        container = self._get_container_for_ip_network(ip_network)
-        for netmask, node in container.items():
-            if (netmask & ip_decimal_repr) in node:
-                return node[netmask & ip_decimal_repr]
+    def delete(self, item):
+        key = item_to_string(item)
+        self.redis.hdel("pycrowdsec_cache", key)
 
     def __len__(self):
-        length = 0
-        for _, items in chain(
-            self.ipv4_nodes_by_netmask.items(), self.ipv6_nodes_by_netmask.items()
-        ):
-            length += len(items)
-        return length
-
-    def __eq__(self, other):
-        return (
-            self.ipv4_nodes_by_netmask == other.ipv4_nodes_by_netmask
-            and self.ipv6_nodes_by_netmask == other.ipv6_nodes_by_netmask
-        )
+        return self.redis.hlen("pycrowdsec_cache")

--- a/src/pycrowdsec/cache.py
+++ b/src/pycrowdsec/cache.py
@@ -62,7 +62,7 @@ class RedisCache:
         responses = self.redis.hmget("pycrowdsec_cache", check_for)
         for response in responses:
             if response:
-                return response
+                return response.decode()
 
     def insert(self, item, action):
         key = item_to_string(item)

--- a/src/pycrowdsec/client.py
+++ b/src/pycrowdsec/client.py
@@ -7,6 +7,32 @@ from pycrowdsec.cache import Cache, RedisCache
 
 logger = logging.getLogger(__name__)
 
+class QueryClient:
+    def __init__(
+        self,
+        api_key,
+        lapi_url="http://localhost:8080/",
+        user_agent="python-bouncer/0.0.1",
+    ):
+        """
+        Parameters
+        ----------
+        api_key(Required) : str
+            Bouncer key for CrowdSec API.
+        lapi_url(Optional) : str
+            Base URL of CrowdSec API. Default is http://localhost:8080/ .
+        """
+
+        self.api_key = api_key
+        self.lapi_url = lapi_url
+        self.user_agent = user_agent
+
+    def get_action_for(self, item):
+        resp = requests.get(f"{self.lapi_url}v1/decisions?ip={item}", headers={
+            "X-Api-Key": self.api_key
+        }).json()
+        if resp:
+            return max(resp, key=lambda d : d["id"])["type"]
 
 class StreamClient:
     def __init__(

--- a/src/pycrowdsec/client.py
+++ b/src/pycrowdsec/client.py
@@ -1,11 +1,9 @@
 import threading
 import logging
 from time import sleep
-import redis
-
 import requests
 
-from pycrowdsec.cache import Cache
+from pycrowdsec.cache import Cache, RedisCache
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +33,7 @@ class StreamClient:
             List of decision scopes which shall be fetched. Default is ["ip", "range"]
         """
         if "redis_connection" in kwargs:
-            self.cache = Cache(redis_connection=kwargs["redis_connection"])
+            self.cache = RedisCache(redis_connection=kwargs["redis_connection"])
         else:
             self.cache = Cache()
 

--- a/src/pycrowdsec/client.py
+++ b/src/pycrowdsec/client.py
@@ -1,12 +1,14 @@
 import threading
 import logging
 from time import sleep
+import redis
 
 import requests
 
 from pycrowdsec.cache import Cache
 
 logger = logging.getLogger(__name__)
+
 
 class StreamClient:
     def __init__(
@@ -16,6 +18,7 @@ class StreamClient:
         interval=15,
         user_agent="python-bouncer/0.0.1",
         scopes=["ip", "range"],
+        **kwargs,
     ):
         """
         Parameters
@@ -31,7 +34,11 @@ class StreamClient:
         scopes(Optional) : List[str]
             List of decision scopes which shall be fetched. Default is ["ip", "range"]
         """
-        self.cache = Cache()
+        if "redis_connection" in kwargs:
+            self.cache = Cache(redis_connection=kwargs["redis_connection"])
+        else:
+            self.cache = Cache()
+
         self.api_key = api_key
         self.scopes = scopes
         self.interval = int(interval)

--- a/src/pycrowdsec/client.py
+++ b/src/pycrowdsec/client.py
@@ -7,6 +7,7 @@ from pycrowdsec.cache import Cache, RedisCache
 
 logger = logging.getLogger(__name__)
 
+
 class QueryClient:
     def __init__(
         self,
@@ -28,11 +29,12 @@ class QueryClient:
         self.user_agent = user_agent
 
     def get_action_for(self, item):
-        resp = requests.get(f"{self.lapi_url}v1/decisions?ip={item}", headers={
-            "X-Api-Key": self.api_key
-        }).json()
+        resp = requests.get(
+            f"{self.lapi_url}v1/decisions?ip={item}", headers={"X-Api-Key": self.api_key}
+        ).json()
         if resp:
-            return max(resp, key=lambda d : d["id"])["type"]
+            return max(resp, key=lambda d: d["id"])["type"]
+
 
 class StreamClient:
     def __init__(

--- a/src/pycrowdsec/flask/__init__.py
+++ b/src/pycrowdsec/flask/__init__.py
@@ -1,5 +1,8 @@
 def get_crowdsec_middleware(
-    actions_by_name, crowdsec_cache, ip_transformers=[lambda request: request.remote_addr], exclude_views=[]
+    actions_by_name,
+    crowdsec_cache,
+    ip_transformers=[lambda request: request.remote_addr],
+    exclude_views=[],
 ):
     """
     Returns a middleware function for flask, which can be registered by passsing it to app.before_request

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -2,149 +2,149 @@ import random
 from unittest import TestCase
 
 from pycrowdsec.cache import Cache
-from pycrowdsec.cache import IPCache
 
 
-class TestIPCache(TestCase):
+class TestIPv4Cache(TestCase):
     def setUp(self):
-        self.ip_cache = IPCache()
+        self.cache = Cache()
 
-
-class TestIPv4Cache(TestIPCache):
     def test_insert_delete(self):
-        self.ip_cache.insert("1.2.3.4", "ban")
-        assert self.ip_cache.get_action_for("1.2.3.4") == "ban"
-        assert self.ip_cache.get_action_for("1.2.3.5") is None
+        self.cache.insert("1.2.3.4", "ban")
+        assert self.cache.get("1.2.3.4") == "ban"
+        assert self.cache.get("1.2.3.5") is None
 
-        self.ip_cache.delete("1.2.3.4")
-        assert self.ip_cache.get_action_for("1.2.3.4") is None
-        assert self.ip_cache.get_action_for("1.2.3.5") is None
+        self.cache.delete("1.2.3.4")
+        assert self.cache.get("1.2.3.4") is None
+        assert self.cache.get("1.2.3.5") is None
 
     def test_range_simple_range(self):
-        self.ip_cache.insert("0.0.0.0/24", "ban")
+        self.cache.insert("0.0.0.0/24", "ban")
         for i in range(256):
             ip = f"0.0.0.{i}"
             with self.subTest(ip=ip):
-                assert self.ip_cache.get_action_for(ip) == "ban"
+                assert self.cache.get(ip) == "ban"
 
-        assert self.ip_cache.get_action_for(f"0.0.1.0") is None
-        assert self.ip_cache.get_action_for("::") is None
+        assert self.cache.get(f"0.0.1.0") is None
+        assert self.cache.get("::") is None
 
-        self.ip_cache.delete("0.0.0.0/24")
+        self.cache.delete("0.0.0.0/24")
         for i in range(256):
-            assert self.ip_cache.get_action_for(f"0.0.0.{i}") is None
+            assert self.cache.get(f"0.0.0.{i}") is None
 
     def test_range_all_match(self):
-        self.ip_cache.insert("0.0.0.0/0", "ban")
+        self.cache.insert("0.0.0.0/0", "ban")
         ip_parts = [str(i) for i in range(256)]
         for _ in range(20):
             ip = ".".join(random.choices(ip_parts, k=4))
             with self.subTest(ip=ip):
-                assert self.ip_cache.get_action_for(ip) == "ban"
+                assert self.cache.get(ip) == "ban"
 
-        self.ip_cache.delete("0.0.0.0/0")
+        self.cache.delete("0.0.0.0/0")
         for _ in range(20):
             ip = ".".join(random.choices(ip_parts, k=4))
             with self.subTest(ip=ip):
-                assert self.ip_cache.get_action_for(ip) is None
+                assert self.cache.get(ip) is None
 
     def test_range_overlap(self):
         def assert_state(a, b, c):
-            assert self.ip_cache.get_action_for("0.0.1.2") == a
-            assert self.ip_cache.get_action_for("0.0.255.255") == b
-            self.ip_cache.get_action_for("0.1.255.255") == c
+            assert self.cache.get("0.0.1.2") == a
+            assert self.cache.get("0.0.255.255") == b
+            self.cache.get("0.1.255.255") == c
 
         assert_state(None, None, None)
-        self.ip_cache.insert("0.0.0.0/16", "ban")
+        self.cache.insert("0.0.0.0/16", "ban")
         assert_state("ban", "ban", None)
 
-        self.ip_cache.insert("0.0.0.0/8", "captcha")
+        self.cache.insert("0.0.0.0/8", "captcha")
         assert_state("ban", "ban", "captcha")
 
-        self.ip_cache.insert("0.0.1.0/24", "throttle")
+        self.cache.insert("0.0.1.0/24", "throttle")
         assert_state("throttle", "ban", "captcha")
 
-        self.ip_cache.delete("0.0.1.0/24")
+        self.cache.delete("0.0.1.0/24")
         assert_state("ban", "ban", "captcha")
 
-        self.ip_cache.delete("0.0.0.0/8")
+        self.cache.delete("0.0.0.0/8")
         assert_state("ban", "ban", None)
 
-        self.ip_cache.delete("0.0.0.0/16")
+        self.cache.delete("0.0.0.0/16")
         assert_state(None, None, None)
 
 
-class TestIPv6Cache(TestIPCache):
-    def test_insert_delete(self):
-        assert self.ip_cache.get_action_for("::") is None
-        self.ip_cache.insert("::", "ban")
-        assert self.ip_cache.get_action_for("::") == "ban"
-        assert self.ip_cache.get_action_for("1::") is None
+class TestIPv6Cache(TestCase):
+    def setUp(self):
+        self.cache = Cache()
 
-        self.ip_cache.delete("::")
-        assert self.ip_cache.get_action_for("1.2.3.4") is None
-        assert self.ip_cache.get_action_for("1.2.3.5") is None
+    def test_insert_delete(self):
+        assert self.cache.get("::") is None
+        self.cache.insert("::", "ban")
+        assert self.cache.get("::") == "ban"
+        assert self.cache.get("1::") is None
+
+        self.cache.delete("::")
+        assert self.cache.get("1.2.3.4") is None
+        assert self.cache.get("1.2.3.5") is None
 
     def test_range_simple_range(self):
-        self.ip_cache.insert("::/112", "ban")
+        self.cache.insert("::/112", "ban")
         ips_to_check = random.choices(range(65535), k=100)
         for i in ips_to_check:
             ip = f"::{format(i, 'x')}"
             with self.subTest(ip=ip):
-                assert self.ip_cache.get_action_for(ip) == "ban"
+                assert self.cache.get(ip) == "ban"
 
-        assert self.ip_cache.get_action_for(f"1::") is None
-        assert self.ip_cache.get_action_for("0.0.0.0") is None
+        assert self.cache.get(f"1::") is None
+        assert self.cache.get("0.0.0.0") is None
 
-        self.ip_cache.delete("::/112")
+        self.cache.delete("::/112")
         for i in ips_to_check:
             ip = f"::{format(i, 'x')}"
             with self.subTest(ip=ip):
-                assert self.ip_cache.get_action_for(ip) is None
+                assert self.cache.get(ip) is None
 
     def test_range_all_match(self):
-        self.ip_cache.insert("::/0", "ban")
+        self.cache.insert("::/0", "ban")
         ip_parts = [format(i, "x") for i in range(65535)]
         for _ in range(20):
             ip = ":".join(random.choices(ip_parts, k=8))
             with self.subTest(ip=ip):
-                assert self.ip_cache.get_action_for(ip) == "ban"
+                assert self.cache.get(ip) == "ban"
 
-        self.ip_cache.delete("::/0")
+        self.cache.delete("::/0")
         for _ in range(20):
             ip = ":".join(random.choices(ip_parts, k=8))
             with self.subTest(ip=ip):
-                assert self.ip_cache.get_action_for(ip) is None
+                assert self.cache.get(ip) is None
 
     def test_range_overlap(self):
         def assert_state(a, b, c):
-            assert self.ip_cache.get_action_for("::ffff") == a
-            assert self.ip_cache.get_action_for("::1:ffff") == b
-            self.ip_cache.get_action_for("::1:ffff:ffff") == c
+            assert self.cache.get("::ffff") == a
+            assert self.cache.get("::1:ffff") == b
+            self.cache.get("::1:ffff:ffff") == c
 
         assert_state(None, None, None)
-        self.ip_cache.insert("::/112", "ban")
+        self.cache.insert("::/112", "ban")
         assert_state("ban", None, None)
 
-        self.ip_cache.insert("::/98", "captcha")
+        self.cache.insert("::/98", "captcha")
         assert_state("ban", "captcha", None)
 
-        self.ip_cache.insert("::/82", "throttle")
+        self.cache.insert("::/82", "throttle")
         assert_state("ban", "captcha", "throttle")
 
-        self.ip_cache.insert("::ffff/128", "block")
+        self.cache.insert("::ffff/128", "block")
         assert_state("block", "captcha", "throttle")
 
-        self.ip_cache.delete("::ffff/128")
+        self.cache.delete("::ffff/128")
         assert_state("ban", "captcha", "throttle")
 
-        self.ip_cache.delete("::/82")
+        self.cache.delete("::/82")
         assert_state("ban", "captcha", None)
 
-        self.ip_cache.delete("::/98")
+        self.cache.delete("::/98")
         assert_state("ban", None, None)
 
-        self.ip_cache.delete("::/112")
+        self.cache.delete("::/112")
         assert_state(None, None, None)
 
 

--- a/tests/test_redis_integration.py
+++ b/tests/test_redis_integration.py
@@ -1,0 +1,54 @@
+import unittest
+
+from pycrowdsec.cache import Cache
+from redislite import Redis
+
+
+class TestRedisIntegration(unittest.TestCase):
+    def setUp(self) -> None:
+        self.redis = Redis()
+        self.cache = Cache()
+        self.cache.use_redis = True
+        self.cache.redis = self.redis
+
+    def test_store_normal_to_redis(self):
+        assert not self.redis.exists("pycrowdsec_cache")
+        self.cache.insert("124122", "ban")
+        assert self.redis.exists("pycrowdsec_cache")
+        assert self.redis.hget("pycrowdsec_cache", b"normal_124122") == b"ban"
+
+    def test_ip_to_redis(self):
+        self.cache.insert("1.2.3.4", "captcha")
+        self.cache.insert("::ffff", "captcha")
+        assert self.redis.hgetall("pycrowdsec_cache") == {
+            b"ipv4_4294967295_16909060": b"captcha",
+            b"ipv6_340282366920938463463374607431768211455_65535": b"captcha",
+        }
+
+    def test_load_from_redis(self):
+        self.cache.insert("1.2.3.4", "captcha")
+        self.cache.insert("::ffff", "captcha")
+        self.cache.insert("TH", "ban")
+        old_cache = self.cache
+
+        new_cache = Cache()
+        new_cache.redis = self.redis
+
+        new_cache.load_from_redis()
+        assert new_cache == old_cache
+
+    def test_delete(self):
+        self.cache.insert("1.2.3.4", "captcha")
+        self.cache.insert("::ffff", "captcha")
+        self.cache.insert("TH", "ban")
+
+        assert len(self.redis.hgetall("pycrowdsec_cache")) == 3
+
+        self.cache.delete("TH")
+        assert len(self.redis.hgetall("pycrowdsec_cache")) == 2
+        self.cache.delete("1.2.3.4")
+
+        assert len(self.redis.hgetall("pycrowdsec_cache")) == 1
+        self.cache.delete("::ffff")
+
+        assert len(self.redis.hgetall("pycrowdsec_cache")) == 0


### PR DESCRIPTION
To use redis in the bouncer, the python redis client must be installed via
```bash
pip install redis
```
Then in the bouncer
```python
import redis
redis_connection = redis.Redis(host='localhost', port=6379, db=0)
c = StreamClient(
    api_key=os.environ.get("CROWDSEC_LAPI_KEY"),  # your crowdsec LAPI bouncer key goes here
    redis_connection=redis_connection
)
```

Internally, in redis items are stored as keys inside a hash. 

See the https://github.com/sbs2001/pycrowdsec/blob/ffd0b0d6c3cfab085eca961e6885b25c69a6cbc0/src/pycrowdsec/cache.py#L51 and https://github.com/sbs2001/pycrowdsec/blob/ffd0b0d6c3cfab085eca961e6885b25c69a6cbc0/src/pycrowdsec/cache.py#L67 methods for details about insertion and retrieval. This includes resolving ip ranges etc

Eg redis data looks like
```
localhost:6379> HGETALL pycrowdsec_cache
  1) "ipv4_4294967295_1399722005"
  2) "ban"
  3) "ipv4_4294967295_765132691"
  4) "ban"
  5) "normal_CN"
  6) "captcha"
```

